### PR TITLE
Daniel backend

### DIFF
--- a/app-electron/src/backend/ipc/IPCclientes.js
+++ b/app-electron/src/backend/ipc/IPCclientes.js
@@ -32,7 +32,7 @@ ipcMain.handle('clientes:getAllClients', async () => {
 });
 
 // Get Client by ID
-ipcMain.handle('clientes:getClientById', async (event, id) => {
+ipcMain.handle('clientes:getClientByID', async (event, id) => {
   try {
     const { data, error } = await getClientByID(id);
     if (error) {

--- a/app-electron/src/preload.js
+++ b/app-electron/src/preload.js
@@ -12,7 +12,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   createUser: (userData) => ipcRenderer.invoke("usuarios:create", userData),
   signOutAndClear: () => ipcRenderer.invoke("usuarios:logout"),
   getAllClients: () => ipcRenderer.invoke("clientes:getAllClients"),
-  getClientByID: (id) => ipcRenderer.invoke("clientes:getClientById", id),
+  getClientByID: (id) => ipcRenderer.invoke("clientes:getClientByID", id),
   getClientByName: (name) =>
     ipcRenderer.invoke("clientes:getClientByName", name),
   createClient: (clientData) =>

--- a/app-electron/src/preload.js
+++ b/app-electron/src/preload.js
@@ -12,7 +12,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   createUser: (userData) => ipcRenderer.invoke('usuarios:create', userData),
   signOutAndClear: () => ipcRenderer.invoke('usuarios:logout'),
   getAllClients: () => ipcRenderer.invoke('clientes:getAllClients'),
-  getClientByID: (id) => ipcRenderer.invoke('clientes:getClientById', id),
+  getClientByID: (id) => ipcRenderer.invoke('clientes:getClientByID', id),
   getClientByName: (name) => ipcRenderer.invoke('clientes:getClientByName', name),
   createClient: (clientData) => ipcRenderer.invoke('clientes:create', clientData),
   updateClient: (id, updates) => ipcRenderer.invoke('clientes:update', { id, updates }),

--- a/app-electron/src/scripts/clientes.js
+++ b/app-electron/src/scripts/clientes.js
@@ -44,7 +44,9 @@ function openEditModal(clientId) {
   editModal.classList.remove("hidden");
 
   // Cargar datos del cliente en el modal
-  window.electronAPI.getClientById(clientId).then((result) => {
+  window.electronAPI.getClientByID(clientId).then((result) => {
+    console.log("ID proporcionado desde el frontend:", clientId); // Log del ID proporcionado
+    console.log("Resultado de getClientById:", result); // Log del resultado obtenido
     if (result.error) {
       console.error("Error al obtener cliente para editar:", result.error);
       alert("Error al cargar datos del cliente.");


### PR DESCRIPTION
This pull request focuses on standardizing the naming convention for a key method related to retrieving client data by ID. The changes ensure consistency in method names across the codebase and add debugging logs to improve troubleshooting.

### Standardization of method naming:

* [`app-electron/src/backend/ipc/IPCclientes.js`](diffhunk://#diff-2e6dcaec9b0c2d04cd4e3d61917b92dbb5fd523361ed33cf0512d55b5d3240ffL35-R35): Renamed the IPC handler from `clientes:getClientById` to `clientes:getClientByID` to align with naming conventions.
* [`app-electron/src/preload.js`](diffhunk://#diff-6273bd3092164ff9adae023f3cc76c7506641f171bbbaafc3f24612bbd6c3cceL15-R15): Updated the method exposed in `electronAPI` from `getClientById` to `getClientByID` to match the renamed IPC handler.
* [`app-electron/src/scripts/clientes.js`](diffhunk://#diff-fb55c4de6eb1784f6fa38ccfa466832f1950bf1d53159e79446d8358129875f0L47-R49): Replaced `window.electronAPI.getClientById` with `window.electronAPI.getClientByID` in the `openEditModal` function to reflect the updated method name.

### Debugging improvements:

* [`app-electron/src/scripts/clientes.js`](diffhunk://#diff-fb55c4de6eb1784f6fa38ccfa466832f1950bf1d53159e79446d8358129875f0L47-R49): Added logs in the `openEditModal` function to display the provided client ID and the result of the `getClientByID` method call, aiding in debugging issues during client data retrieval.